### PR TITLE
Set tabstop and softtabstop to 2

### DIFF
--- a/indent/jade.vim
+++ b/indent/jade.vim
@@ -11,7 +11,7 @@ endif
 unlet! b:did_indent
 let b:did_indent = 1
 
-setlocal autoindent sw=2 et
+setlocal autoindent sw=2 ts=2 sts=2 et
 setlocal indentexpr=GetJadeIndent()
 setlocal indentkeys=o,O,*<Return>,},],0),!^F
 


### PR DESCRIPTION
I normally use 4 spaces for tabs, which makes auto indent and tab keys inconsistent.
I think it should set tabstop to 2 as well if it is going to set shiftwidth.
