### PR TITLE
add support for coffee-script syntax highlighting using vim-coffee-script

### DIFF
--- a/syntax/jade.vim
+++ b/syntax/jade.vim
@@ -14,6 +14,7 @@ endif
 
 runtime! syntax/html.vim
 runtime! syntax/html/html5.vim
+silent! syntax include @htmlCoffeescript syntax/coffee.vim
 unlet! b:current_syntax
 
 syn case match
@@ -51,7 +52,8 @@ syn region  jadeAttributeString start=+\%(=\s*\)\@<="+ skip=+\%(\\\\\)*\\'+ end=
 syn region  jadeAttributeString start=+\%(:\s*\)\@<="+ skip=+\%(\\\\\)*\\'+ end=+"+ contains=jadeInterpolation
 
 syn region  jadeJavascriptFilter matchgroup=jadeFilter start="^\z(\s*\):javascript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlJavascript
-syn region  jadePlainFilter matchgroup=jadeFilter start="^\z(\s*\):\%(markdown\|sass\|less\|cdata\|coffeescript\)\s*$" end="^\%(\z1 \| *$\)\@!"
+syn region  jadeCoffeescriptFilter matchgroup=jadeFilter start="^\z(\s*\):coffeescript\s*$" end="^\%(\z1 \| *$\)\@!" contains=@htmlCoffeescript
+syn region  jadePlainFilter matchgroup=jadeFilter start="^\z(\s*\):\%(markdown\|sass\|less\|cdata\)\s*$" end="^\%(\z1 \| *$\)\@!"
 
 syn region  jadeJavascriptBlock start="^\z(\s*\)script" nextgroup=@jadeComponent,jadeError end="^\%(\z1 \| *$\)\@!" contains=@jadeTop,@htmlJavascript keepend
 syn region  jadeCssBlock        start="^\z(\s*\)style" nextgroup=@jadeComponent,jadeError  end="^\%(\z1 \| *$\)\@!" contains=@jadeTop,@htmlCss keepend


### PR DESCRIPTION
If someone has their coffee-script in a jade file, they probably have vim-coffee-script. If they don't , the old (confused) highlighting method IMO is better than plainsyntax.
