### PR TITLE
Add syntax highlighting for `doctype`

### DIFF
--- a/syntax/jade.vim
+++ b/syntax/jade.vim
@@ -36,7 +36,7 @@ syn match   jadeBlockExpansionChar ":\s" contained nextgroup=jadeTag
 syn match   jadeIdChar "#{\@!" contained nextgroup=jadeId
 syn match   jadeClass "\%(\w\|-\)\+" contained nextgroup=@jadeComponent
 syn match   jadeId "\%(\w\|-\)\+" contained nextgroup=@jadeComponent
-syn region  jadeDocType start="^\s*!!!" end="$"
+syn region  jadeDocType start="^\s*\(!!!\|doctype\)" end="$"
 " Unless I'm mistaken, syntax/html.vim requires
 " that the = sign be present for these matches.
 " This adds the matches back for jade.


### PR DESCRIPTION
Small change to add syntax highlighting when `doctype` keyword is used instead of `!!!`
These represent the same token in the jade grammar.

See: https://github.com/visionmedia/jade/blob/master/lib/lexer.js#L241-243
