### PR TITLE
Recognize `+<mixin>` mixins as tags

### DIFF
--- a/syntax/jade.vim
+++ b/syntax/jade.vim
@@ -26,7 +26,7 @@ syn region  jadeJavascript matchgroup=jadeJavascriptOutputChar start="[!&]\==\|\
 syn region  jadeJavascript matchgroup=jadeJavascriptChar start="-" skip=",\s*$" end="$" contained contains=@htmlJavascript keepend
 syn cluster jadeTop contains=jadeBegin,jadeComment,jadeHtmlComment,jadeJavascript
 syn match   jadeBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=jadeTag,jadeClassChar,jadeIdChar,jadePlainChar,jadeJavascript,jadeScriptConditional,jadeScriptStatement
-syn match   jadeTag "\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@jadeComponent
+syn match   jadeTag "+\?\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@jadeComponent
 syn cluster jadeComponent contains=jadeAttributes,jadeIdChar,jadeBlockExpansionChar,jadeClassChar,jadePlainChar,jadeJavascript
 syn match   jadeComment ' *\/\/.*$'
 syn region  jadeHtmlComment start="^\z(\s*\)/"  end="^\%(\z1 \| *$\)\@!"


### PR DESCRIPTION
This change allows the `+<mixin>(<attributes>)` syntax to be highlighted the same as tags. (Example: `+item(name="test")`.) This highlights the attributes and nested tags (e.g. `+item(name="foo"): p bar`). For documentation on these mixins, see https://github.com/visionmedia/jade/blob/master/jade.md.

I just changed the tag syntax to allow a `+` before the tag name. Not sure if this is the best way to get this accomplished or not.
