### PR TITLE
Add Jade comment characters to comments setting

### DIFF
--- a/ftplugin/jade.vim
+++ b/ftplugin/jade.vim
@@ -43,7 +43,7 @@ if exists("loaded_matchit")
   let b:match_words = s:match_words
 endif
 
-setlocal comments= commentstring=//\ %s
+setlocal comments=://-,:// commentstring=//\ %s
 
 let b:undo_ftplugin = "setl cms< com< "
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin


### PR DESCRIPTION
This will enable the proper functionality in Vim of extending comment blocks automatically (that is, if you enter a new line in a comment, the next line will continue the comment) and wrapping text if you have `formatoptions+=c` set (I like to wrap my comments at 72 columns).
