### PR TITLE
Enable jump to file on abbreviated `include`

### DIFF
--- a/ftplugin/jade.vim
+++ b/ftplugin/jade.vim
@@ -45,6 +45,8 @@ endif
 
 setlocal comments=://-,:// commentstring=//\ %s
 
+setlocal suffixesadd=.jade
+
 let b:undo_ftplugin = "setl cms< com< "
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
 


### PR DESCRIPTION
For the jade:

```
include tile
```

If you do `gf` on `tile` it should automatically check for (and 
jump to) `tile.jade`
