### PR TITLE
Fixes digitaltoad/vim-jade#37

### DIFF
--- a/ftplugin/jade.vim
+++ b/ftplugin/jade.vim
@@ -45,7 +45,7 @@ endif
 
 setlocal comments=://-,:// commentstring=//\ %s
 
-setlocal suffixesadd=.jade
+setlocal suffixesadd+=.jade
 
 let b:undo_ftplugin = "setl cms< com< "
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin


### PR DESCRIPTION
Fixing the `suffixesadd` option to add .jade to the list rather than make it the only one allowing :find, gf to work for other suffixes as per users configuration.
