### PR TITLE
Add Inline Tag support.

### DIFF
--- a/syntax/jade.vim
+++ b/syntax/jade.vim
@@ -27,15 +27,15 @@ syn cluster htmlJavascript add=javascriptParenthesisBlock
 syn region  jadeJavascript matchgroup=jadeJavascriptOutputChar start="[!&]\==\|\~" skip=",\s*$" end="$" contained contains=@htmlJavascript keepend
 syn region  jadeJavascript matchgroup=jadeJavascriptChar start="-" skip=",\s*$" end="$" contained contains=@htmlJavascript keepend
 syn cluster jadeTop contains=jadeBegin,jadeComment,jadeHtmlComment,jadeJavascript
-syn match   jadeBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=jadeTag,jadeClassChar,jadeIdChar,jadePlainChar,jadeJavascript,jadeScriptConditional,jadeScriptStatement
+syn match   jadeBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=jadeTag,jadeClassChar,jadeIdChar,jadePlainChar,jadeJavascript,jadeScriptConditional,jadeScriptStatement,jadePipedText
 syn match   jadeTag "+\?\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@jadeComponent
-syn cluster jadeComponent contains=jadeAttributes,jadeIdChar,jadeBlockExpansionChar,jadeClassChar,jadePlainChar,jadeJavascript
+syn cluster jadeComponent contains=jadeAttributes,jadeIdChar,jadeBlockExpansionChar,jadeClassChar,jadePlainChar,jadeJavascript,jadeTagBlockChar,jadeTagInlineText
 syn match   jadeComment '\s*\/\/.*$'
 syn region  jadeHtmlComment start="^\z(\s*\)/"  end="^\%(\z1\s\|\s*$\)\@!"
 syn region  jadeAttributes matchgroup=jadeAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,jadeHtmlArg,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@jadeComponent
 syn match   jadeClassChar "\." contained nextgroup=jadeClass
-syn match   jadeBlockExpansionChar ":\s" contained nextgroup=jadeTag
-syn match   jadeIdChar "#{\@!" contained nextgroup=jadeId
+syn match   jadeBlockExpansionChar ":\s\+" contained nextgroup=jadeTag
+syn match   jadeIdChar "#[[{]\@!" contained nextgroup=jadeId
 syn match   jadeClass "\%(\w\|-\)\+" contained nextgroup=@jadeComponent
 syn match   jadeId "\%(\w\|-\)\+" contained nextgroup=@jadeComponent
 syn region  jadeDocType start="^\s*\(!!!\|doctype\)" end="$"
@@ -47,6 +47,11 @@ syn keyword jadeHtmlArg contained href title
 syn match   jadePlainChar "\\" contained
 syn region  jadeInterpolation matchgroup=jadeInterpolationDelimiter start="#{" end="}" contains=@htmlJavascript
 syn match   jadeInterpolationEscape "\\\@<!\%(\\\\\)*\\\%(\\\ze#{\|#\ze{\)"
+syn match   jadeTagInlineText "\s.*$" contained contains=jadeInterpolation,jadeTextInlineJade
+syn region  jadePipedText matchgroup=jadePipeChar start="|" end="$" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadePipedText skipnl
+syn match   jadeTagBlockChar "\.$" contained nextgroup=jadeTagBlockText skipnl
+syn region  jadeTagBlockText start="\s*\S" end="$" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadeTagBlockText skipnl
+syn region  jadeTextInlineJade matchgroup=jadeInlineDelimiter start="#\[" end="]" contained contains=jadeTag keepend
 
 syn region  jadeJavascriptFilter matchgroup=jadeFilter start="^\z(\s*\):javascript\s*$" end="^\%(\z1\s\|\s*$\)\@!" contains=@htmlJavascript
 syn region  jadeCoffeescriptFilter matchgroup=jadeFilter start="^\z(\s*\):coffeescript\s*$" end="^\%(\z1\s\|\s*$\)\@!" contains=@htmlCoffeescript
@@ -75,9 +80,12 @@ hi def link jadeAttributesDelimiter    Identifier
 hi def link jadeIdChar                 Special
 hi def link jadeClassChar              Special
 hi def link jadeBlockExpansionChar     Special
+hi def link jadePipeChar               Special
+hi def link jadeTagBlockChar           Special
 hi def link jadeId                     Identifier
 hi def link jadeClass                  Type
 hi def link jadeInterpolationDelimiter Delimiter
+hi def link jadeInlineDelimiter        Delimiter
 hi def link jadeFilter                 PreProc
 hi def link jadeDocType                PreProc
 hi def link jadeComment                Comment


### PR DESCRIPTION
As discussed at visionmedia/jade/pull/1323, [Jade](visionmedia/jade) now can embed tags "inline" in plain text, using the delimiters `#[` and `]`. For example:

``` jade
  a(href='/') #[i Emphasized] Home Page
```

[haha it looks like github syntax coloring needs an update for this too] becomes:

``` html
  <a href="/"><i>Emphasized</i> Home Page</a>
```

This is quite useful!

I made two new syntax matches, `jadeTagInlineText` and `jadeTagBlockChar`, and three new syntax regions: `jadePipedText`, `jadeTagBlockText`, and `jadeTextInlineJade`. Each of the three "Text" items `contains` the new `jadeTextInlineJade` region as well as the pre-existing `jadeInterpolation` region.

I also added a `\+` to the regex for `jadeBlockExpansionChar`, so that it can handle more than one space between the colon and the next tag. This is consistent with Jade's behavior.
