### PR TITLE
Notice the end of jadeTagBlockText

### DIFF
--- a/syntax/jade.vim
+++ b/syntax/jade.vim
@@ -49,8 +49,9 @@ syn region  jadeInterpolation matchgroup=jadeInterpolationDelimiter start="#{" e
 syn match   jadeInterpolationEscape "\\\@<!\%(\\\\\)*\\\%(\\\ze#{\|#\ze{\)"
 syn match   jadeTagInlineText "\s.*$" contained contains=jadeInterpolation,jadeTextInlineJade
 syn region  jadePipedText matchgroup=jadePipeChar start="|" end="$" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadePipedText skipnl
-syn match   jadeTagBlockChar "\.$" contained nextgroup=jadeTagBlockText skipnl
-syn region  jadeTagBlockText start="\s*\S" end="$" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadeTagBlockText skipnl
+syn match   jadeTagBlockChar "\.$" contained nextgroup=jadeTagBlockText,jadeTagBlockEnd skipnl
+syn region  jadeTagBlockText start="\%(\s*\)\S" end="\ze\n\1" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadeTagBlockText,jadeTagBlockEnd skipnl
+syn region  jadeTagBlockEnd start="\s*\S" end="$" contained contains=jadeInterpolation,jadeTextInlineJade nextgroup=jadeBegin skipnl
 syn region  jadeTextInlineJade matchgroup=jadeInlineDelimiter start="#\[" end="]" contained contains=jadeTag keepend
 
 syn region  jadeJavascriptFilter matchgroup=jadeFilter start="^\z(\s*\):javascript\s*$" end="^\%(\z1\s\|\s*$\)\@!" contains=@htmlJavascript


### PR DESCRIPTION
This fixes a regression from my last PR, for the situation in which a tag-block is followed immediately (i.e. no intervening blank line) with another tag:

``` jade
  p.
    Here is a paragraph.
  p
```

With the most recent pull the second tag is not recognized. This commit fixes that by treating the last line of a tag-block differently than the preceding lines.

`jadeTagBlockText` can continue for any number of lines, but after the last line of similar indentation we should be looking for tags, etc. again. The new syntax region `jadeTagBlockEnd` does this.
