### PR TITLE
Indent on trailing "." for tag-block.

### DIFF
--- a/indent/jade.vim
+++ b/indent/jade.vim
@@ -60,7 +60,7 @@ function! GetJadeIndent()
     return increase
   elseif line =~? '^\v%('.g:jade_self_closing_tags.')>'
     return indent
-  elseif group =~? '\v^%(jadeAttributesDelimiter|jadeClass|jadeId|htmlTagName|htmlSpecialTagName|jadeFilter)$'
+  elseif group =~? '\v^%(jadeAttributesDelimiter|jadeClass|jadeId|htmlTagName|htmlSpecialTagName|jadeFilter|jadeTagBlockChar)$'
     return increase
   else
     return indent


### PR DESCRIPTION
Adding `jadeTagBlockChar`, which is just a "." at the end of a tag line, to the list of syntax groups that cause an increase in indentation. This is appropriate because this forms a "tag block". Tag blocks are the easiest way to include large blocks of text in the html element generated by the tag:

``` jade
  p.
    Here is a big block of text that will be inside the paragraph
    element and you will note that we didn't even have to use any of
    those funny-looking pipes!
```

[Oy that looks funny in pygments. Actually vim-jade is still recognizing html elements at the beginning of a line inside tag blocks so I'll fix that eventually too. Maybe later I'll look at pygments' issues.]
