### PR TITLE
Consider adding support for Amber, a Jade / Pug derivative...

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -35,7 +35,7 @@ syn cluster pugComponent contains=pugAttributes,pugIdChar,pugBlockExpansionChar,
 syn match   pugComment '\(\s\+\|^\)\/\/.*$'
 syn region  pugCommentBlock start="\z(\s\+\|^\)\/\/.*$" end="^\%(\z1\s\|\s*$\)\@!" keepend 
 syn region  pugHtmlConditionalComment start="<!--\%(.*\)>" end="<!\%(.*\)-->"
-syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,pugHtmlArg,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
+syn region  pugAttributes matchgroup=pugAttributesDelimiter start="[(\[]" end="[\])]" contained contains=@htmlJavascript,pugHtmlArg,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
 syn match   pugClassChar "\." contained nextgroup=pugClass
 syn match   pugBlockExpansionChar ":\s\+" contained nextgroup=pugTag,pugClassChar,pugIdChar
 syn match   pugIdChar "#[[{]\@!" contained nextgroup=pugId


### PR DESCRIPTION
Our development team uses [Amber](/eknkc/amber) for server-side templates, which is derived from Jade / Pug. The first syntactical difference I can detect so far is the use of square brackets for attributes instead of parens, so this patch would support syntax highlighting for Amber as well as Jade/Pug. As I find more differences, I'm happy to continue updating this branch. Thanks!