### PR TITLE
Correct highlighting of classes with custom components

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -37,7 +37,7 @@ syn match   pugComment '\(\s\+\|^\)\/\/.*$' contains=pugCommentTodo
 syn region  pugCommentBlock start="\z(\s\+\|^\)\/\/.*$" end="^\%(\z1\s\|\s*$\)\@!" contains=pugCommentTodo keepend
 syn region  pugHtmlConditionalComment start="<!--\%(.*\)>" end="<!\%(.*\)-->" contains=pugCommentTodo
 syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,pugHtmlArg,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
-syn match   pugClassChar "\." contained nextgroup=pugClass
+syn match   pugClassChar "\." containedin=htmlTagName nextgroup=pugClass
 syn match   pugBlockExpansionChar ":\s\+" contained nextgroup=pugTag,pugClassChar,pugIdChar
 syn match   pugIdChar "#[[{]\@!" contained nextgroup=pugId
 syn match   pugClass "\%(\w\|-\)\+" contained nextgroup=@pugComponent


### PR DESCRIPTION
Closes #93 

The issue was arising as a result of a dot being a valid ending character for a custom html tag name. Since pug is incapable of handling this correctly anyway, we can make dots in a tag name appear as classes - which is what pug would decide to do.