### PR TITLE
Added support for angular2 event syntax highlighting

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -36,7 +36,8 @@ syntax keyword pugCommentTodo  contained TODO FIXME XXX TBD
 syn match   pugComment '\(\s\+\|^\)\/\/.*$' contains=pugCommentTodo
 syn region  pugCommentBlock start="\z(\s\+\|^\)\/\/.*$" end="^\%(\z1\s\|\s*$\)\@!" contains=pugCommentTodo keepend
 syn region  pugHtmlConditionalComment start="<!--\%(.*\)>" end="<!\%(.*\)-->" contains=pugCommentTodo
-syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,pugHtmlArg,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
+syn region  pugAngular2 start="(" end=")" contains=htmlEvent
+syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,pugHtmlArg,pugAngular2,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
 syn match   pugClassChar "\." containedin=htmlTagName nextgroup=pugClass
 syn match   pugBlockExpansionChar ":\s\+" contained nextgroup=pugTag,pugClassChar,pugIdChar
 syn match   pugIdChar "#[[{]\@!" contained nextgroup=pugId


### PR DESCRIPTION
This prevents the breaking of syntax in pug `attributes` where they contain inner parenthesis

problem example:
`td((click)='selectYear(year)') {{year}}`

problem explanation:
The closing parenthesis after the word `click` would causes the pug `attribute` to be closed, where that is not the case.
