### PR TITLE
Fix hyphened tag highlighting

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -30,7 +30,7 @@ syn region  pugJavascript matchgroup=pugJavascriptOutputChar start="[!&]\==\|\~"
 syn region  pugJavascript matchgroup=pugJavascriptChar start="-" skip=",\s*$" end="$" contained contains=@htmlJavascript keepend
 syn cluster pugTop contains=pugBegin,pugComment,pugHtmlComment,pugJavascript
 syn match   pugBegin "^\s*\%([<>]\|&[^=~ ]\)\@!" nextgroup=pugTag,pugClassChar,pugIdChar,pugPlainChar,pugJavascript,pugScriptConditional,pugScriptStatement,pugPipedText
-syn match   pugTag "+\?\w\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@pugComponent
+syn match   pugTag "+\?[[:alnum:]_-]\+\%(:\w\+\)\=" contained contains=htmlTagName,htmlSpecialTagName nextgroup=@pugComponent
 syn cluster pugComponent contains=pugAttributes,pugIdChar,pugBlockExpansionChar,pugClassChar,pugPlainChar,pugJavascript,pugTagBlockChar,pugTagInlineText
 syntax keyword pugCommentTodo  contained TODO FIXME XXX TBD
 syn match   pugComment '\(\s\+\|^\)\/\/.*$' contains=pugCommentTodo


### PR DESCRIPTION
Using a tag with hyphens such as "text-button", caused the highlighter to ignore it as a tag and start treating the rest of the line as JS, which made things very confusing once you tried to use a JS reserved keyword such as "class", making a mess out of the rest of the template.

Example:
![Wrong syntax highlighting](https://cloud.githubusercontent.com/assets/3057302/22981328/4653d4dc-f383-11e6-9172-5e1e706d7b42.png)

This is especially important for the use of custom tags (which pug supports) which usually use hyphens as separators.