### PR TITLE
Added syntax for yaml frontmatter

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -75,6 +75,13 @@ syn region  pugCoffeescriptFilter matchgroup=pugFilter start="^\z(\s*\):coffee-\
 syn region  pugJavascriptTag contained start="^\z(\s*\)script\%(:\w\+\)\=" end="$" contains=pugBegin,pugTag
 syn region  pugCssBlock        start="^\z(\s*\)style" nextgroup=@pugComponent,pugError  end="^\%(\z1\s\|\s*$\)\@!" contains=@htmlCss keepend
 
+" YAML frontmatter
+if get(g:, 'vim_markdown_frontmatter', 0)
+  syn include @yamlTop syntax/yaml.vim
+  syn region Comment matchgroup=mkdDelimiter start="\%^---$" end="^---$" contains=@yamlTop keepend
+  unlet! b:current_syntax
+endif
+
 syn match  pugError "\$" contained
 
 hi def link pugPlainChar              Special


### PR DESCRIPTION
I was working with [wintersmith-jade](https://github.com/smebberson/wintersmith-jade), which uses YAML frontmatter at the top of jade files. This pull simply adds YAML highlighting such a frontmatter block, if it is present.

Not sure how common having YAML frontmatter is in jade. Feel free to reject this if it's outside the scope of this project :)