### PR TITLE
Fix speed issue with Javascript plugin(s)

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -37,7 +37,9 @@ syn match   pugComment '\(\s\+\|^\)\/\/.*$' contains=pugCommentTodo,@Spell
 syn region  pugCommentBlock start="\z(\s\+\|^\)\/\/.*$" end="^\%(\z1\s\|\s*$\)\@!" contains=pugCommentTodo,@Spell keepend
 syn region  pugHtmlConditionalComment start="<!--\%(.*\)>" end="<!\%(.*\)-->" contains=pugCommentTodo,@Spell
 syn region  pugAngular2 start="(" end=")" contains=htmlEvent
-syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=@htmlJavascript,pugHtmlArg,pugAngular2,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
+syn region  pugJavascriptString start=+"+  skip=+\\\("\|$\)+  end=+"\|$+ contained
+syn region  pugJavascriptString start=+'+  skip=+\\\('\|$\)+  end=+'\|$+ contained
+syn region  pugAttributes matchgroup=pugAttributesDelimiter start="(" end=")" contained contains=pugJavascriptString,pugHtmlArg,pugAngular2,htmlArg,htmlEvent,htmlCssDefinition nextgroup=@pugComponent
 syn match   pugClassChar "\." containedin=htmlTagName nextgroup=pugClass
 syn match   pugBlockExpansionChar ":\s\+" contained nextgroup=pugTag,pugClassChar,pugIdChar
 syn match   pugIdChar "#[[{]\@!" contained nextgroup=pugId
@@ -99,6 +101,7 @@ hi def link pugCommentTodo            Todo
 hi def link pugComment                Comment
 hi def link pugCommentBlock           Comment
 hi def link pugHtmlConditionalComment pugComment
+hi def link pugJavascriptString       String
 
 let b:current_syntax = "pug"
 


### PR DESCRIPTION
## Fixes
- Very slow with any javascript syntax plugin https://github.com/digitaltoad/vim-pug/issues/80
- javascript syntax makes jade syntax unusable https://github.com/sheerun/vim-polyglot/issues/83
- Slow to open Jade files https://github.com/sheerun/vim-polyglot/issues/117

## How to reproduce
1. Install vim-pug
2. Install one of the many javacript syntax plugins out there
3. Open a large .pug or .jade file 

## Problem
vim-pug throws everything between attribute parentheses at the installed javascript plugin to parse. This creates a lot of overhead since the attributes go through rigorous javascript syntax checking.

## Solution
Pug attributes follow the `key=("|')value("\')` format from javascript.  Knowing this, we extract the relevant `region` from https://github.com/pangloss/vim-javascript/blob/master/syntax/javascript.vim and put it into vim-pug.