### PR TITLE
fix(regression): form interpreted as pugScriptLoopRegion

### DIFF
--- a/syntax/pug.vim
+++ b/syntax/pug.vim
@@ -69,7 +69,7 @@ syn region  pugPlainFilter matchgroup=pugFilter start="^\z(\s*\):\%(sass\|less\|
 
 syn match  pugScriptConditional "^\s*\<\%(if\|else\|else if\|elif\|unless\|while\|until\|case\|when\|default\)\>[?!]\@!"
 syn match  pugScriptStatement "^\s*\<\%(each\|for\|block\|prepend\|append\|mixin\|extends\|include\)\>[?!]\@!"
-syn region  pugScriptLoopRegion start="^\s*\(for\|each\)" end="$" contains=pugScriptLoopKeywords
+syn region  pugScriptLoopRegion start="^\s*\(for \|each \)" end="$" contains=pugScriptLoopKeywords
 syn keyword  pugScriptLoopKeywords contained for each in
 
 syn region  pugJavascript start="^\z(\s*\)script\%(:\w\+\)\=" end="^\%(\z1\s\|\s*$\)\@!" contains=@htmlJavascript,pugJavascriptTag,pugCoffeescriptFilter keepend


### PR DESCRIPTION
On the commit 862314141a689770ecf85076a8fa36600ecb66f7, it was added
the `each` keyword to the vim-pug syntax/plug.vim

However, it doesn't check if there is a `m` after `for`, making `form` a
`pugScriptLoopRegion` instead of a `htmlTagName`.

A single space fixes the issue.

Before:
![image](https://user-images.githubusercontent.com/7634886/58696515-1e546780-836e-11e9-88d1-90520398ced2.png)

After:
![image](https://user-images.githubusercontent.com/7634886/58696451-f5cc6d80-836d-11e9-860f-e6998b01f37c.png)
